### PR TITLE
Remove now outdated text from browser homepage

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -33,13 +33,6 @@
           <p>This genome browser displays the variant frequencies
           obtained for the 1000 individuals the SweGen dataset, using
           software from the Exome Aggregation Consortium (ExAC).</p>
-
-          <p>Please note that variant frequencies on chrX and Y are not
-          displayed correctly in the current SweGen browser. The SweGen
-          dataset consists sequences from 506 males and 494 females,
-          which implies a total number of 1494 X chromosomes, and 506
-          Y chromosomes in the dataset. The current version displays a
-          total of 2000 both for chrX and chrY.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Remove no longer needed text.

This change is already live.